### PR TITLE
Refactor to use Eloquent for Orders

### DIFF
--- a/config/samcart.php
+++ b/config/samcart.php
@@ -1,0 +1,7 @@
+<?php
+
+return [
+
+    'model' => \Mikemartin\Samcart\Models\Order::class,
+
+];

--- a/database/migrations/2021_01_18_205958_create_orders_table.php
+++ b/database/migrations/2021_01_18_205958_create_orders_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateOrdersTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('orders', function (Blueprint $table) {
+            $table->id();
+            $table->string('title');
+            $table->json('product')->nullable();
+            $table->json('customer')->nullable();
+            $table->json('order')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('orders');
+    }
+}

--- a/database/migrations/2021_01_18_205958_create_orders_table.php
+++ b/database/migrations/2021_01_18_205958_create_orders_table.php
@@ -16,6 +16,7 @@ class CreateOrdersTable extends Migration
         Schema::create('orders', function (Blueprint $table) {
             $table->id();
             $table->string('title');
+            $table->integer('order_number');
             $table->json('product')->nullable();
             $table->json('customer')->nullable();
             $table->json('order')->nullable();

--- a/src/Http/Controllers/WebhookController.php
+++ b/src/Http/Controllers/WebhookController.php
@@ -3,7 +3,6 @@
 namespace Mikemartin\Samcart\Http\Controllers;
 
 use Illuminate\Http\Request;
-use Mikemartin\Samcart\Models\Order;
 use Statamic\Facades\Entry;
 use Statamic\Facades\User;
 
@@ -61,7 +60,7 @@ class WebhookController
         }
 
         // Create Order model from request object
-        if (Order::where('order_number', $slug)->count() == 0) {
+        if (resolve(config('samcart.model'))::where('order_number', $slug)->count() == 0) {
             $this->createOrder($request, $slug);
         }
 
@@ -81,7 +80,7 @@ class WebhookController
     {
         $data['title'] = 'Order #'.$slug;
 
-        return Order::create([
+        return resolve(config('samcart.model'))::create([
             'title' => $data['title'],
             'order_number' => $slug,
             'product' => $data['product'],

--- a/src/Http/Controllers/WebhookController.php
+++ b/src/Http/Controllers/WebhookController.php
@@ -3,15 +3,14 @@
 namespace Mikemartin\Samcart\Http\Controllers;
 
 use Illuminate\Http\Request;
+use Mikemartin\Samcart\Models\Order;
 use Statamic\Facades\Entry;
 use Statamic\Facades\User;
-use Statamic\Facades\Stache;
 
 class WebhookController
 {
     public function store(Request $request)
     {
-
         // Validate the user input
         $validatedData = $request->validate([
             'order.id' => 'required|numeric',
@@ -61,8 +60,8 @@ class WebhookController
             ->save();
         }
 
-        // Create Order entry from request object
-        if (!Entry::findBySlug($slug, 'orders')) {
+        // Create Order model from request object
+        if (Order::where('order_number', $slug)->count() == 0) {
             $this->createOrder($request, $slug);
         }
 
@@ -82,13 +81,12 @@ class WebhookController
     {
         $data['title'] = 'Order #'.$slug;
 
-        return Entry::make()
-            ->collection('orders')
-            ->locale('default')
-            ->data($data)
-            ->slug($slug)
-            ->date(now())
-            ->set('updated_at', now()->timestamp)
-            ->save();
+        return Order::create([
+            'title' => $data['title'],
+            'order_number' => $slug,
+            'product' => $data['product'],
+            'customer' => $data['customer'],
+            'order' => $data['order'],
+        ]);
     }
 }

--- a/src/Models/Order.php
+++ b/src/Models/Order.php
@@ -7,7 +7,7 @@ use Illuminate\Database\Eloquent\Model;
 class Order extends Model
 {
     protected $fillable = [
-        'title', 'product', 'customer', 'order', 'updated_at', 'created_at',
+        'title', 'order_number', 'product', 'customer', 'order', 'updated_at', 'created_at',
     ];
 
     protected $casts = [

--- a/src/Models/Order.php
+++ b/src/Models/Order.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Mikemartin\Samcart\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Order extends Model
+{
+    protected $fillable = [
+        'title', 'product', 'customer', 'order', 'updated_at', 'created_at',
+    ];
+
+    protected $casts = [
+        'product' => 'json',
+        'customer' => 'json',
+        'order' => 'json',
+    ];
+}

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -6,8 +6,14 @@ use Statamic\Providers\AddonServiceProvider;
 
 class ServiceProvider extends AddonServiceProvider
 {
-
     protected $routes = [
         'actions' => __DIR__.'/../routes/actions.php',
     ];
+    
+    public function boot()
+    {
+        parent::boot();
+
+        $this->loadMigrationsFrom(__DIR__.'/../database/migrations');
+    }
 }


### PR DESCRIPTION
This pull request adds what's needed to use Eloquent instead of entries to store the orders. Here's a quick review of the changes I've made:

* Added an optional config file, in case the user wants to override the `Order` model
* Added a migration in here for the `orders` table. 
* Refactored the webhook controller to save to the Eloquent model instead of to an Entry
* Added a base `Order` model