### PR TITLE
Remove products for Refunds, Delinquent and Cancellations

### DIFF
--- a/src/Http/Controllers/WebhookController.php
+++ b/src/Http/Controllers/WebhookController.php
@@ -68,9 +68,8 @@ class WebhookController
 
         // Remove products for refund, cancellations and delinquents
         if ($type == 'Refund' || $type == 'SubscriptionDelinquent' || $type == 'Cancel' ) {
-          // Unsubscribe existing user from product
           $memberProducts = $member->value('products') ?? [];
-
+          // Unsubscribe existing user from product
           foreach($products as $product){
             $memberProducts = collect($memberProducts)->reject($product)->sort()->values()->toArray();
           }

--- a/src/Http/Controllers/WebhookController.php
+++ b/src/Http/Controllers/WebhookController.php
@@ -72,7 +72,7 @@ class WebhookController
           $memberProducts = $member->value('products') ?? [];
 
           foreach($products as $product){
-            $memberProducts = collect($memberProducts)->reject($product);
+            $memberProducts = collect($memberProducts)->reject($product)->sort()->values()->toArray();
           }
 
           $member->set('products', $memberProducts)


### PR DESCRIPTION
Added support for more webhook actions to remove products when the notify url action is **Refund**, **Cancel** or **SubscriptionDelinquent**. 
See https://help.samcart.com/support/solutions/articles/60000506436-notify-url